### PR TITLE
Avoid StackOverflowError while parsing lazy indirect objects which po…

### DIFF
--- a/src/main/java/org/sejda/sambox/input/LazyIndirectObjectsProvider.java
+++ b/src/main/java/org/sejda/sambox/input/LazyIndirectObjectsProvider.java
@@ -207,6 +207,20 @@ class LazyIndirectObjectsProvider implements IndirectObjectsProvider
         {
             LOG.warn("Missing 'endobj' token for {}", xrefEntry);
         }
+
+        if(found instanceof ExistingIndirectCOSObject)
+        {
+            ExistingIndirectCOSObject existingIndirectCOSObject = (ExistingIndirectCOSObject)found;
+            // does this point to itself? it would cause a StackOverflowError. Example:
+            // 9 0 obj
+            // 9 0 R
+            // endobj
+            if(existingIndirectCOSObject.id().objectIdentifier.equals(xrefEntry.key()))
+            {
+                LOG.warn("Found indirect object definition pointing to itself, for {}", xrefEntry);
+                found = COSNull.NULL;
+            }
+        }
         store.put(xrefEntry.key(), ofNullable(found).orElse(COSNull.NULL));
     }
 


### PR DESCRIPTION
…int to themselves, such as:

```
9 0 obj
9 0 R
endobj
```
```
java.lang.StackOverflowError
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at org.sejda.sambox.input.LazyIndirectObjectsProvider.get(LazyIndirectObjectsProvider.java:73)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.getCOSObject(ExistingIndirectCOSObject.java:53)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
	at org.sejda.sambox.input.ExistingIndirectCOSObject.accept(ExistingIndirectCOSObject.java:68)
```