### PR TITLE
Lenient parsing: accept negative obj gen num?

### DIFF
--- a/src/main/java/org/sejda/sambox/xref/XrefEntry.java
+++ b/src/main/java/org/sejda/sambox/xref/XrefEntry.java
@@ -40,8 +40,6 @@ public class XrefEntry
 
     XrefEntry(XrefType type, long objectNumber, long byteOffset, int generationNumber)
     {
-        requireArg(objectNumber >= 0 && generationNumber >= 0,
-                "Object number and generation number cannot be negative");
         this.type = type;
         this.key = new COSObjectKey(objectNumber, generationNumber);
         this.byteOffset = byteOffset;

--- a/src/test/java/org/sejda/sambox/input/AbstractXrefTableParserTest.java
+++ b/src/test/java/org/sejda/sambox/input/AbstractXrefTableParserTest.java
@@ -232,7 +232,7 @@ public class AbstractXrefTableParserTest
         assertEquals(3, found.size());
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void parseNegativeGeneration() throws IOException
     {
         Set<XrefEntry> found = new HashSet<>();

--- a/src/test/java/org/sejda/sambox/xref/XrefEntryTest.java
+++ b/src/test/java/org/sejda/sambox/xref/XrefEntryTest.java
@@ -35,13 +35,13 @@ import org.sejda.sambox.cos.COSObjectKey;
 public class XrefEntryTest
 {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void negativeObjectNumber()
     {
         inUseEntry(-10, 10, 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void negativeGenerationNumber()
     {
         inUseEntry(10, 10, -10);


### PR DESCRIPTION
I'm finding documents with negative generation numbers - we reject parsing them, but all other PDF viewers seem to render them OK.

Is there a specific reason we're rejecting to parse if obj/gen num are negative?
Do you see any drawback to removing this requirement?