### PR TITLE
Optimized COSFloat and SourceReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ What's different from PDFBox?
 + Requires JDK 17
 + Lazy loading/parsing of PDF objects. Only the document xref table(s)/stream(s) is(are) initially parsed and information to lookup objects are retrieved, when later a PDF object is requested, the object is retrieve/parsed using the lookup information. This allows minimal memory footprint when you only need part of the document (Ex. you only need the information dictionary or the number of pages of the document).
 + Multiple I/O implementations to read from. SAMBox uses [Sejda-io](https://github.com/torakiki/sejda-io) allowing to use one of the provided implementation based on `java.nio.channels.FileChannel`, `java.io.InputStream` and `java.nio.MappedByteBuffer` (buffered or not).
-+ Minimized GC through the use of a pool of `java.lang.StringBuilder`.
 + PDF streams are read directly from the underlying source through the concept of bounded views.
 + Use and discard of lazy PDF objects. PDF objects can be written (sync/async) and discarded as soon as they have been written, this is particularly useful with existing documents where objects are lazy loaded, written and then discarded, keeping a low memory footprint.
 + All the I/O and parsing logic has been refactored to smaller classes which are nearly 100% unit tested. 

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <version>1.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/src/main/java/org/sejda/sambox/cos/COSFloat.java
+++ b/src/main/java/org/sejda/sambox/cos/COSFloat.java
@@ -16,6 +16,7 @@
  */
 package org.sejda.sambox.cos;
 
+import static java.util.Objects.isNull;
 import static org.sejda.commons.util.RequireUtils.requireIOCondition;
 
 import java.io.IOException;
@@ -26,11 +27,9 @@ import java.util.regex.Pattern;
  * This class represents a floating point number in a PDF document.
  *
  * @author Ben Litchfield
- * 
  */
 public class COSFloat extends COSNumber
 {
-    private float value;
     private static final Pattern DOTS = Pattern.compile("\\.");
     private static final Pattern EXP_END = Pattern.compile("[e|E]$");
     private static final Pattern NUM1 = Pattern.compile("^(-)([-|+]+)\\d+\\.\\d+");
@@ -39,9 +38,13 @@ public class COSFloat extends COSNumber
     private static final Pattern ZERO = Pattern.compile("^0-(\\.|\\d+)*");
     private static final Pattern MINUS = Pattern.compile("-");
 
+    private float value;
+    private String stringValue;
+
     public COSFloat(float value)
     {
-        this.value = value;
+        this.value = coerce(value);
+        this.stringValue = formatString();
     }
 
     /**
@@ -54,7 +57,12 @@ public class COSFloat extends COSNumber
         {
             // no pre-processing! speed optimized for the vanilla scenario where we parse good floats
             // if we encounter a problem, then we start handling edge cases, not before
-            value = Float.parseFloat(aFloat);
+            var parsedValue = Float.parseFloat(aFloat);
+            value = coerce(parsedValue);
+            if (parsedValue == value)
+            {
+                this.stringValue = aFloat;
+            }
         }
         catch (NumberFormatException e)
         {
@@ -69,7 +77,7 @@ public class COSFloat extends COSNumber
 
                 }
                 aFloat = EXP_END.matcher(aFloat).replaceAll("");
-                value = Float.parseFloat(aFloat);
+                value = coerce(Float.parseFloat(aFloat));
             }
             catch (NumberFormatException nfex)
             {
@@ -78,7 +86,7 @@ public class COSFloat extends COSNumber
                     if (NUM1.matcher(aFloat).matches())
                     {
                         // PDFBOX-3589 --242.0
-                        value = Float.parseFloat(NUM2.matcher(aFloat).replaceFirst("-"));
+                        value = coerce(Float.parseFloat(NUM2.matcher(aFloat).replaceFirst("-")));
                     }
                     else if (ZERO.matcher(aFloat).matches())
                     {
@@ -92,7 +100,8 @@ public class COSFloat extends COSNumber
                         // PDFBOX-3500 has 0.-262
                         requireIOCondition(NUM3.matcher(aFloat).matches(),
                                 "Expected floating point number but found '" + aFloat + "'");
-                        value = Float.parseFloat("-" + MINUS.matcher(aFloat).replaceFirst(""));
+                        value = coerce(
+                                Float.parseFloat("-" + MINUS.matcher(aFloat).replaceFirst("")));
                     }
                 }
                 catch (NumberFormatException e2)
@@ -102,7 +111,10 @@ public class COSFloat extends COSNumber
                 }
             }
         }
-        value = coerce(value);
+        if (isNull(this.stringValue))
+        {
+            this.stringValue = formatString();
+        }
     }
 
     private float coerce(float floatValue)
@@ -122,6 +134,16 @@ public class COSFloat extends COSNumber
             return 0f;
         }
         return floatValue;
+    }
+
+    private String formatString()
+    {
+        var s = String.valueOf(value);
+        if (s.indexOf('E') < 0)
+        {
+            return s;
+        }
+        return new BigDecimal(s).stripTrailingZeros().toPlainString();
     }
 
     @Override
@@ -151,8 +173,8 @@ public class COSFloat extends COSNumber
     @Override
     public boolean equals(Object o)
     {
-        return o instanceof COSFloat
-                && Float.floatToIntBits(((COSFloat) o).value) == Float.floatToIntBits(value);
+        return o instanceof COSFloat cosfloat
+                && Float.floatToIntBits(cosfloat.value) == Float.floatToIntBits(value);
     }
 
     @Override
@@ -164,12 +186,7 @@ public class COSFloat extends COSNumber
     @Override
     public String toString()
     {
-        var s = String.valueOf(value);
-        if (s.indexOf('E') < 0)
-        {
-            return s;
-        }
-        return new BigDecimal(s).stripTrailingZeros().toPlainString();
+        return stringValue;
     }
 
     @Override

--- a/src/main/java/org/sejda/sambox/cos/COSNumber.java
+++ b/src/main/java/org/sejda/sambox/cos/COSNumber.java
@@ -16,11 +16,10 @@
  */
 package org.sejda.sambox.cos;
 
-import java.io.IOException;
-import java.util.regex.Pattern;
-
 import static org.sejda.commons.util.RequireUtils.requireArg;
 import static org.sejda.commons.util.RequireUtils.requireNotNullArg;
+
+import java.io.IOException;
 
 /**
  * This class represents an abstract number in a PDF document.

--- a/src/test/java/org/sejda/sambox/cos/COSFloatTest.java
+++ b/src/test/java/org/sejda/sambox/cos/COSFloatTest.java
@@ -16,17 +16,16 @@
  */
 package org.sejda.sambox.cos;
 
-import org.junit.Test;
-import org.sejda.sambox.TestUtils;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.sejda.sambox.TestUtils;
 
 /**
  * @author Andrea Vacondio
- *
  */
 public class COSFloatTest
 {
@@ -50,12 +49,6 @@ public class COSFloatTest
     }
 
     @Test
-    public void doubleValue() throws IOException
-    {
-        assertEquals(2.04, COSFloat.get("2.04").doubleValue(), 0);
-    }
-
-    @Test
     public void floatValue() throws IOException
     {
         assertEquals(2.04f, COSFloat.get("2.04").floatValue(), 0);
@@ -76,7 +69,7 @@ public class COSFloatTest
     @Test(expected = IOException.class)
     public void invalidExponential() throws IOException
     {
-        new COSFloat("4.72856f");
+        new COSFloat("4.72856k");
     }
 
     @Test

--- a/src/test/java/org/sejda/sambox/cos/COSFloatTest.java
+++ b/src/test/java/org/sejda/sambox/cos/COSFloatTest.java
@@ -55,6 +55,12 @@ public class COSFloatTest
     }
 
     @Test
+    public void precisionToString() throws IOException
+    {
+        assertEquals("83745.38273645", COSFloat.get("83745.38273645").toString());
+    }
+
+    @Test
     public void emptyExponentialValue() throws IOException
     {
         assertEquals(4.72856f, COSFloat.get("4.72856e").floatValue(), 0);
@@ -203,4 +209,29 @@ public class COSFloatTest
         assertEquals(-Float.MAX_VALUE, cosFloat.floatValue(), 0);
     }
 
+    @Test
+    public void floatInfinity()
+    {
+        var victim = new COSFloat(Float.POSITIVE_INFINITY);
+        assertEquals(Float.MAX_VALUE, victim.floatValue(), 0);
+        assertEquals(new BigDecimal(String.valueOf(Float.MAX_VALUE)).toPlainString(),
+                victim.toString());
+    }
+
+    @Test
+    public void floatNegativeInfinity()
+    {
+        var victim = new COSFloat(Float.NEGATIVE_INFINITY);
+        assertEquals(-Float.MAX_VALUE, victim.floatValue(), 0);
+        assertEquals(new BigDecimal(String.valueOf(-Float.MAX_VALUE)).toPlainString(),
+                victim.toString());
+    }
+
+    @Test
+    public void stringRepresentationOfInvalid() throws IOException
+    {
+        var victim = new COSFloat("0.00-35095424");
+        assertEquals(new BigDecimal("-0.0035095424").toPlainString(), victim.toString());
+
+    }
 }

--- a/src/test/java/org/sejda/sambox/input/SourceReaderTest.java
+++ b/src/test/java/org/sejda/sambox/input/SourceReaderTest.java
@@ -104,7 +104,7 @@ public class SourceReaderTest
     public void skipToken() throws IOException
     {
         victim = new SourceReader(inMemorySeekableSourceFrom("Chuck Norris".getBytes()));
-        assertTrue(victim.skipTokenIfValue("Segal", "Chuck"));
+        assertTrue(victim.skipTokenIfValue("Chuck"));
         assertEquals(5, victim.position());
     }
 
@@ -113,7 +113,7 @@ public class SourceReaderTest
     {
         victim = new SourceReader(inMemorySeekableSourceFrom("XXXChuck Norris".getBytes()));
         victim.offset(3);
-        assertTrue(victim.skipTokenIfValue("Segal", "Chuck"));
+        assertTrue(victim.skipTokenIfValue("Chuck"));
         assertEquals(5, victim.position());
     }
 
@@ -122,7 +122,7 @@ public class SourceReaderTest
     {
         victim = new SourceReader(inMemorySeekableSourceFrom("Chuck Norris".getBytes()));
         victim.position(5);
-        assertFalse(victim.skipTokenIfValue("Segal", "Van Damme"));
+        assertFalse(victim.skipTokenIfValue("Segal"));
         assertEquals(5, victim.position());
     }
 


### PR DESCRIPTION
This PR brings our `COSFloat` in line with the one in PDFBox (minus the fact we handle more corner cases) and removes the pool of `StringBuilder`s from the `SourceReader`.
I benchmarked the changes using JMH and 4 different files, a small one, a book with a lot of text, a map drawing converted from a DWG and a mixed file with text and images. I corrupted the xref table for each of them so it triggers a full scan and these are the results:
**Just read the file.**
Before
![read_3 0 15](https://github.com/user-attachments/assets/53c305b5-4769-46fb-ac82-392af1084fce)
and after
![read_3 0 16-SNAPSHOT](https://github.com/user-attachments/assets/7ef0c900-cb76-4bc3-b622-4c6f8ab53872)

**Read and write to a temp file**.
Before
![read_write_3 0 15](https://github.com/user-attachments/assets/2f245959-4cb9-4035-a9b1-f1f730d94943)
and after
![read_write_3 0 16-SNAPSHOT](https://github.com/user-attachments/assets/389154e1-5c90-4579-8bed-d3318fdb1880)

and finally I profiled the memory usage with IntelliJ profiler for the read and write and it seems it consumes less memory. I wasn't expecting it but it seems the pool wasn't doing any good.
Before
![memory_3 0 15](https://github.com/user-attachments/assets/60b9e5e6-d693-460a-acc6-2ab1b2f5e509)
and after
![memory_3 0 16-SNAPSHOT](https://github.com/user-attachments/assets/2a2c99a0-4a31-4536-b0c2-a1971f5dbf01)


