### PR TITLE
Performance improvement for COSFloat.

### DIFF
--- a/src/main/java/org/sejda/sambox/cos/COSFloat.java
+++ b/src/main/java/org/sejda/sambox/cos/COSFloat.java
@@ -16,38 +16,35 @@
  */
 package org.sejda.sambox.cos;
 
+import static java.util.Objects.isNull;
+import static org.sejda.commons.util.RequireUtils.requireIOCondition;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.regex.Pattern;
-
-import static org.sejda.commons.util.RequireUtils.requireIOCondition;
 
 /**
  * This class represents a floating point number in a PDF document.
  *
  * @author Ben Litchfield
- * 
  */
-// @formatter:off
 public class COSFloat extends COSNumber
 {
-    private BigDecimal value;
     private static final Pattern DOTS = Pattern.compile("\\.");
     private static final Pattern EXP_END = Pattern.compile("[e|E]$");
     private static final Pattern NUM1 = Pattern.compile("^(-)([-|+]+)\\d+\\.\\d+");
-    private static final Pattern NUM2 = Pattern.compile("^(-)([\\-|\\+]+)");
-    private static final Pattern NUM3 = Pattern.compile("^0\\.0*\\-\\d+");
-    private static final Pattern ZERO = Pattern.compile("^0\\-(\\.|\\d+)*");
-    private static final Pattern MINUS = Pattern.compile("\\-");
+    private static final Pattern NUM2 = Pattern.compile("^(-)([\\-|+]+)");
+    private static final Pattern NUM3 = Pattern.compile("^0\\.0*-\\d+");
+    private static final Pattern ZERO = Pattern.compile("^0-(\\.|\\d+)*");
+    private static final Pattern MINUS = Pattern.compile("-");
 
-    /**
-     * @param aFloat The primitive float object that this object wraps.
-     */
-    public COSFloat(float aFloat)
+    private float value;
+    private String stringValue;
+
+    public COSFloat(float value)
     {
-        // use a BigDecimal as intermediate state to avoid
-        // a floating point string representation of the float value
-        value = new BigDecimal(String.valueOf(aFloat));
+        this.value = coerce(value);
+        this.stringValue = formatString();
     }
 
     /**
@@ -60,8 +57,12 @@ public class COSFloat extends COSNumber
         {
             // no pre-processing! speed optimized for the vanilla scenario where we parse good floats
             // if we encounter a problem, then we start handling edge cases, not before
-            value = new BigDecimal(aFloat);
-            checkMinMaxValues();
+            var parsedValue = Float.parseFloat(aFloat);
+            value = coerce(parsedValue);
+            if (parsedValue == value)
+            {
+                this.stringValue = aFloat;
+            }
         }
         catch (NumberFormatException e)
         {
@@ -71,13 +72,12 @@ public class COSFloat extends COSNumber
                 if (dot != aFloat.lastIndexOf('.'))
                 {
                     // 415.75.795 we replace additional dots with 0
-                    aFloat = aFloat.substring(0, dot + 1)
-                            + DOTS.matcher(aFloat.substring(dot + 1)).replaceAll("0");
+                    aFloat = aFloat.substring(0, dot + 1) + DOTS.matcher(aFloat.substring(dot + 1))
+                            .replaceAll("0");
 
                 }
-                aFloat = EXP_END.matcher(aFloat).replaceAll("");    
-                value = new BigDecimal(aFloat);
-                checkMinMaxValues();
+                aFloat = EXP_END.matcher(aFloat).replaceAll("");
+                value = coerce(Float.parseFloat(aFloat));
             }
             catch (NumberFormatException nfex)
             {
@@ -86,12 +86,12 @@ public class COSFloat extends COSNumber
                     if (NUM1.matcher(aFloat).matches())
                     {
                         // PDFBOX-3589 --242.0
-                        value = new BigDecimal(NUM2.matcher(aFloat).replaceFirst("-"));
+                        value = coerce(Float.parseFloat(NUM2.matcher(aFloat).replaceFirst("-")));
                     }
                     else if (ZERO.matcher(aFloat).matches())
                     {
                         // SAMBox 75
-                        value = BigDecimal.ZERO;
+                        value = 0f;
                     }
                     else
                     {
@@ -100,9 +100,9 @@ public class COSFloat extends COSNumber
                         // PDFBOX-3500 has 0.-262
                         requireIOCondition(NUM3.matcher(aFloat).matches(),
                                 "Expected floating point number but found '" + aFloat + "'");
-                        value = new BigDecimal("-" + MINUS.matcher(aFloat).replaceFirst(""));
+                        value = coerce(
+                                Float.parseFloat("-" + MINUS.matcher(aFloat).replaceFirst("")));
                     }
-                    checkMinMaxValues();
                 }
                 catch (NumberFormatException e2)
                 {
@@ -111,78 +111,82 @@ public class COSFloat extends COSNumber
                 }
             }
         }
+        if (isNull(this.stringValue))
+        {
+            this.stringValue = formatString();
+        }
     }
 
-    private void checkMinMaxValues()
+    private float coerce(float floatValue)
     {
-        float floatValue = value.floatValue();
-        double doubleValue = value.doubleValue();
-        boolean valueReplaced = false;
-        // check for huge values
-        if (floatValue == Float.NEGATIVE_INFINITY || floatValue == Float.POSITIVE_INFINITY)
+        if (floatValue == Float.POSITIVE_INFINITY)
         {
-
-            if (Math.abs(doubleValue) > Float.MAX_VALUE)
-            {
-                floatValue = Float.MAX_VALUE * (floatValue == Float.POSITIVE_INFINITY ? 1 : -1);
-                valueReplaced = true;
-            }
+            return Float.MAX_VALUE;
         }
-        // check for very small values
-        else if (floatValue == 0 && doubleValue != 0 && Math.abs(doubleValue) < Float.MIN_NORMAL)
+        if (floatValue == Float.NEGATIVE_INFINITY)
+        {
+            return -Float.MAX_VALUE;
+        }
+        if (Math.abs(floatValue) < Float.MIN_NORMAL)
         {
             // values smaller than the smallest possible float value are converted to 0
             // see PDF spec, chapter 2 of Appendix C Implementation Limits
-            valueReplaced = true;
+            return 0f;
         }
-        if (valueReplaced)
+        return floatValue;
+    }
+
+    private String formatString()
+    {
+        var s = String.valueOf(value);
+        if (s.indexOf('E') < 0)
         {
-            value = BigDecimal.valueOf(floatValue);
+            return s;
         }
+        return new BigDecimal(s).stripTrailingZeros().toPlainString();
     }
 
     @Override
     public float floatValue()
     {
-        return value.floatValue();
+        return value;
     }
 
     @Override
     public double doubleValue()
     {
-        return value.doubleValue();
+        return value;
     }
 
     @Override
     public long longValue()
     {
-        return value.longValue();
+        return (long) value;
     }
 
     @Override
     public int intValue()
     {
-        return value.intValue();
+        return (int) value;
     }
 
     @Override
     public boolean equals(Object o)
     {
-        return o instanceof COSFloat
-                && Float.floatToIntBits(((COSFloat) o).value.floatValue()) == Float
-                        .floatToIntBits(value.floatValue());
+        return o instanceof COSFloat cosfloat
+                && Float.floatToIntBits(cosfloat.value) == Float.floatToIntBits(value);
     }
 
     @Override
     public int hashCode()
     {
-        return value.hashCode();
+        return Float.hashCode(value);
     }
 
     @Override
     public String toString()
     {
-        return value.stripTrailingZeros().toPlainString();
+        return stringValue;
     }
 
     @Override

--- a/src/main/java/org/sejda/sambox/cos/COSNumber.java
+++ b/src/main/java/org/sejda/sambox/cos/COSNumber.java
@@ -16,11 +16,10 @@
  */
 package org.sejda.sambox.cos;
 
-import java.io.IOException;
-import java.util.regex.Pattern;
-
 import static org.sejda.commons.util.RequireUtils.requireArg;
 import static org.sejda.commons.util.RequireUtils.requireNotNullArg;
+
+import java.io.IOException;
 
 /**
  * This class represents an abstract number in a PDF document.

--- a/src/test/java/org/sejda/sambox/cos/COSFloatTest.java
+++ b/src/test/java/org/sejda/sambox/cos/COSFloatTest.java
@@ -16,17 +16,16 @@
  */
 package org.sejda.sambox.cos;
 
-import org.junit.Test;
-import org.sejda.sambox.TestUtils;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.sejda.sambox.TestUtils;
 
 /**
  * @author Andrea Vacondio
- *
  */
 public class COSFloatTest
 {
@@ -50,15 +49,15 @@ public class COSFloatTest
     }
 
     @Test
-    public void doubleValue() throws IOException
-    {
-        assertEquals(2.04, COSFloat.get("2.04").doubleValue(), 0);
-    }
-
-    @Test
     public void floatValue() throws IOException
     {
         assertEquals(2.04f, COSFloat.get("2.04").floatValue(), 0);
+    }
+
+    @Test
+    public void precisionToString() throws IOException
+    {
+        assertEquals("83745.38273645", COSFloat.get("83745.38273645").toString());
     }
 
     @Test
@@ -76,7 +75,7 @@ public class COSFloatTest
     @Test(expected = IOException.class)
     public void invalidExponential() throws IOException
     {
-        new COSFloat("4.72856f");
+        new COSFloat("4.72856k");
     }
 
     @Test
@@ -210,4 +209,29 @@ public class COSFloatTest
         assertEquals(-Float.MAX_VALUE, cosFloat.floatValue(), 0);
     }
 
+    @Test
+    public void floatInfinity()
+    {
+        var victim = new COSFloat(Float.POSITIVE_INFINITY);
+        assertEquals(Float.MAX_VALUE, victim.floatValue(), 0);
+        assertEquals(new BigDecimal(String.valueOf(Float.MAX_VALUE)).toPlainString(),
+                victim.toString());
+    }
+
+    @Test
+    public void floatNegativeInfinity()
+    {
+        var victim = new COSFloat(Float.NEGATIVE_INFINITY);
+        assertEquals(-Float.MAX_VALUE, victim.floatValue(), 0);
+        assertEquals(new BigDecimal(String.valueOf(-Float.MAX_VALUE)).toPlainString(),
+                victim.toString());
+    }
+
+    @Test
+    public void stringRepresentationOfInvalid() throws IOException
+    {
+        var victim = new COSFloat("0.00-35095424");
+        assertEquals(new BigDecimal("-0.0035095424").toPlainString(), victim.toString());
+
+    }
 }


### PR DESCRIPTION
This PR brings our COSFloat in line with the one in PDFBox (minus the fact we handle more corner cases). It stores the string value read from the file when the conversion is fine (which should be most of the time) and calculates the string representation when the read value needs fixing.
It differs from PDFBox in the `float` constructor where it applies the `coerce` which enforce the float to be inside implementation limits specified in the spec 1.7, not sure why PDFBox applies it only in the `String` constructor.
In PDF spec 2.0 the implementation limits section is different and I couldn't quite understand if they are still valid but we are talking about a corner case that should't make any difference in real life.
It also adds some tests.